### PR TITLE
rename files, to troubleshoot links blocked on the VA Network

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -21,7 +21,7 @@
       alt: Onboard team
 
     - title: Research and Discovery
-      linkto: /delivery/research-and-discovery-1
+      linkto: /delivery/research-and-discovery
       alt: Research and Discovery
       show-tertitems: yes
       tertitems:

--- a/_pages/delivery/archive/build-and-test-2.md
+++ b/_pages/delivery/archive/build-and-test-2.md
@@ -1,0 +1,124 @@
+---
+#
+modified-date: September 19, 2018
+#
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Build and Test activities
+description: During the <i>Build and Test</i> phase, focus on building features in small batches and testing those with real users.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Build and Test
+page-prev: introduction
+phase-next: Build and Test
+page-next: checklist
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/build-and-test/activities
+#
+---
+
+### Key questions to answer
+
+* Which user stories for the MVP are best suited to address basic user needs?
+
+* Does the technical solution work at scale, and do its integrations with other services work well?
+
+* Is the MVP solution consistent with other Veteran Tools Platform design patterns?
+
+* Is the MVP solution accessible?
+
+* Which metrics make sense to measure the success of the MVP?
+
+* What business or policy changes are needed for the MVP?
+
+<hr>
+
+### MVP activities
+
+* Create a *Build and Test* plan that groups the user stories and features you've identified for the MVP into small, testable chunks that you can build, deploy, and test iteratively.
+
+* **<a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-ia-review.md#prepare-for-an-ia-review" target="_blank">Define the information architecture</a>** for your MVP.
+
+* **<a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-ato-reviews.md#request-a-preliminary-ato-review" target="_blank">Request a preliminary ATO review</a>** for your MVP.
+
+* **<a title="Go to developer workflow" href="https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/docs/vets-developer-docs/development-workflow.html" target="_blank">Incrementally develop, deploy, and test</a>** small chunks of the MVP.
+
+  1. Code locally and deploy to staging (with automated testing).
+
+      * <a title="Go to 508 testing" href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Testing/508-automated-testing.md" target="_blank">Automated accessibility (508 compliance) testing</a>
+
+      * <a title="Go to testing" href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Testing/unit-testing.md" target="_blank">Automated unit testing</a> and <a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Testing/end-to-end-testing.md" target="_blank">automated end-to-end testing</a>
+
+  1. **Conduct [user research]({{site.baseurl}}/resources/user-research#plan-a-research-sprint)** to test the deployed features.
+
+      * Focus on <a title="Go to usability testing" href="https://methods.18f.gov/validate/usability-testing/" target="_blank">usability testing</a> to ensure that your staged user stories and features work well for your users.
+
+      * Analyze and synthesize the user feedback you've collected.
+
+      * Document your research findings.
+
+      * Use your research findings to refine your *Build and Test* plan &mdash; adjusting existing features and adding new features (if these are critical to supporting your users' basic needs).
+
+  3. Repeat the cycle of developing incrementally and conducting user research until one of the following is true
+
+      * You've deployed all the features you planned for the MVP service
+
+      * The MVP provides value by meeting basic user needs
+
+* **<a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-ia-review.md#request-an-ia-review" target="_blank">Request an IA Review</a>** for your MVP.
+
+
+* When you've deployed and tested all your MVP features on staging, 
+  * **<a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-design-qa.md" target="_blank">Request a Design QA</a>**.
+
+  * **<a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-content-qa.md" target="_blank">Request a Content QA</a>**.
+
+  * **[Complete the Pre-launch activities](#pre-launch-activities)**.
+
+* Define the metrics you'll use to measure the success of the MVP.
+
+* Create a prioritized backlog of features you plan to build after the MVP launches.
+
+* Create a plan for the *Learn and Improve* phase &#8212; how you’ll monitor, evaluate, user research/test, and build from your backlog.
+
+<hr>
+
+### Pre-launch activities
+
+**Note**: Some of these tasks impact one another. For example, if you change the information architecture, you'll need to test and QA again, and you may need to update the metrics you've set up in Google Analytics.
+
+1. If you've made any changes to your service's information architecture (page titles, URLs, navigation) since your last IA Review with DSVA, you must <a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-ia-review.md#request-an-ia-review" target="_blank">request another IA Review</a>.
+
+1. Request <a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-508-review.md" target="_blank">an Accessibility/508 review</a>.
+
+1. Conduct <a title="Go to qa testing" href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Testing/cross-browser-manual-testing.md" target="_blank">cross-browser QA testing</a>.
+
+1. Set up <a title="Go to Google Analytics setup" href="https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/docs/vets-developer-docs/google-analytics" target="_blank">Google Analytics</a>.
+
+1. Request a <a href="https://github.com/department-of-veterans-affairs/vets-work-practices/blob/master/Reviews-External-Contractors/request-ato-reviews.md#request-a-pre-launch-ato-review" target="_blank">Pre-launch ATO review</a>.
+
+1. Load test your service.
+
+1. Finalize [marketing and communications materials]({{site.baseurl}}/resources/more/marcom).
+
+1. Perform [user acceptance testing (UAT)]({{site.baseurl}}/resources/more/uat).
+
+1. Review your MVP with the [Call Center]({{site.baseurl}}/resources/more/call-center).
+
+<!--1. Set up [live service details]({{site.baseurl}}/resources/more/service-details).-->
+
+
+<br/>

--- a/_pages/delivery/archive/build-and-test-3.md
+++ b/_pages/delivery/archive/build-and-test-3.md
@@ -1,0 +1,76 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Build and Test checklist
+description: The <i>Build and Test</i> phase ends with a Checkpoint meeting to confirm your team is ready to launch the MVP (and move on to the <i>Learn and Improve</i> phase).
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Build and Test
+page-prev: activities
+phase-next: Learn and Improve
+page-next: introduction
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/build-and-test/checklist
+#
+---
+
+### By the end of this phase, you should have answers to these questions
+
+
+<div class="bullet-checkmark" markdown="1">
+
+
+* Does the MVP service meet the basic needs of your users?
+
+* Does it work correctly in the production environment at scale and including all integrations?
+
+* If needed, are the right policies or processes in place to support the MVP when it launches?
+
+* Has the team successfully completed all [the pre-launch activities]({{site.baseurl}}/delivery/build-and-test/activities#pre-launch-activities)?
+
+
+</div>
+
+<hr>
+
+### Completing this phase
+
+#### 1. Schedule a [Checkpoint]({{site.baseurl}}/resources/more/checkpoint) meeting at the end of this phase.
+
+* **Note**: The expectation is that you will launch the MVP after the Checkpoint meeting. Be sure you've completed all the [the pre-launch activities]({{site.baseurl}}/delivery/build-and-test/activities#pre-launch-activities) before then.
+
+#### 2. At the Checkpoint meeting, be prepared with the following:
+
+
+<div class="bullet-checkmark" markdown="1">
+
+* A fully-functioning MVP service that meets your users' basic needs
+
+* A list of major bugs and usability issues that have been identified and fixed
+
+* The metrics you'll use to measure the success of your MVP
+
+* Documentation of the user research and testing you did in the *Build and Test* phase
+
+* A proposed plan for how you'll improve the service after you launch it &mdash; how you'll monitor, evaluate, user research/test, and build from your backlog
+
+* A prioritized backlog of features you plan to build after MVP launch in order to improve the service
+
+</div>
+<br/>

--- a/_pages/delivery/archive/learn-and-improve-2.md
+++ b/_pages/delivery/archive/learn-and-improve-2.md
@@ -1,0 +1,42 @@
+---
+#
+modified-date: September 4, 2018
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Learn and Improve activities
+description: During the <i>Learn and Improve</i> phase, focus on learning about the evolving needs of your users. Then design, build, test, and deploy those features.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Learn and Improve
+page-prev: introduction
+phase-next: Learn and Improve
+page-next: checklist
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/learn-and-improve/activities
+#
+---
+
+### Key questions to answer
+
+#### content in progress
+
+<hr>
+
+### Activities
+
+#### content in progress
+
+<br/>

--- a/_pages/delivery/archive/learn-and-improve-3.md
+++ b/_pages/delivery/archive/learn-and-improve-3.md
@@ -1,0 +1,49 @@
+---
+#
+modified-date: September 4, 2018
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Learn and Improve checklist
+description: If you need to retire your service, be sure your team has a plan to inform users, including what happens to their data and how they can meet the needs your service previously met for them.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Learn and Improve
+page-prev: activities
+phase-next: none
+page-next: none
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/learn-and-improve/checklist
+#
+---
+
+### Before retiring a service, you should have answers to these questions
+
+
+<div class="bullet-checkmark" markdown="1">
+
+
+* **content in progress !**
+
+
+</div>
+
+<hr>
+
+### Before retiring your service
+
+#### 1. content in progress !
+
+<br/>

--- a/_pages/delivery/archive/prototype-2.md
+++ b/_pages/delivery/archive/prototype-2.md
@@ -1,0 +1,61 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Prototype activities
+description: During the <i>Prototype</i> phase, focus on testing many different approaches with real users before you start building the real service.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Prototype
+page-prev: introduction
+phase-next: Prototype
+page-next: checklist
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/prototype/activities
+#
+---
+
+### Key questions to answer
+
+* What user experience (IA, interaction design, content) is best suited to serve user needs?
+
+* What technical solutions or approaches are best suited to deliver the user experience you want?
+
+* What technical solutions or approaches are best suited to integrate with existing Veteran Tools Platform technologies?
+
+<hr>
+
+### Activities
+
+* **[Identify your goals]({{site.baseurl}}/resources/more/prototype-activities#identify-your-goals)** for the *Prototype* phase.
+
+* **[Plan design sprints]({{site.baseurl}}/resources/more/prototype-activities#plan-your-design-sprints)** that answer the questions you identified in your goals.
+
+* **[Conduct design sprints]({{site.baseurl}}/resources/more/prototype-activities#conduct-a-design-sprint)** to test the hypotheses you identified in your goals.
+
+* Document findings from your prototyping activities.
+
+* Based on your prototyping findings, create a clear definition and design of the MVP your team plans to build, including all user stories and features.
+
+* Create a list of user stories and features that you plan to build *after the MVP launch*.
+
+* Document the technology needed to support the MVP, as well as any business or policy changes required by the MVP.
+
+* Create a timeline and plan for the *Build and Test* phase.
+  * Be sure you **understand [the pre-launch activities]({{site.baseurl}}/delivery/build-and-test/activities#pre-launch-activities)** so you can create an effective *Build and Test* plan.
+<br/>

--- a/_pages/delivery/archive/prototype-3.md
+++ b/_pages/delivery/archive/prototype-3.md
@@ -1,0 +1,81 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Prototype checklist
+description: The <i>Prototype</i> phase ends with a Checkpoint meeting to confirm your team is ready to move on the <i>Build and Test</i> phase.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Prototype
+page-prev: activities
+phase-next: Build and Test
+page-next: introduction
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/prototype/checklist
+#
+---
+
+### By the end of this phase, you should have answers to these questions
+
+
+<div class="bullet-checkmark" markdown="1">
+
+* Have you defined the right MVP service to meet the basic needs of your users?
+
+* What existing (and/or new) design patterns are needed for the MVP?
+
+* What APIs will the MVP use (if any), and how do you plan to use them?
+
+* What integrations are required for the MVP (if any), and how do you plan to integrate them?
+
+* What existing processes or policies need to change to support the MVP (if any)?
+
+* What are the metrics you'll use to measure the success of the MVP, and what is your plan to get those metrics?
+
+
+</div>
+
+<hr>
+
+### Completing this phase
+
+#### 1. Schedule a [Checkpoint]({{site.baseurl}}/resources/more/checkpoint) meeting at the end of this phase.
+
+#### 2. At the Checkpoint meeting, be prepared with the following:
+
+
+<div class="bullet-checkmark" markdown="1">
+
+* A clear vision and definition for the MVP service you'll build in the next phase (see [MVP scope]({{site.baseurl}}/resources/more/mvp-scope))
+
+* Thoroughly tested prototypes that illustrate the design of the MVP service
+
+* A prioritized list of user stories and features for the MVP service (i.e., your backlog)
+
+* A clear understanding of the technology that will support the MVP service (and an understanding of how the technology might evolve for later releases)
+
+* An understanding of other VA systems you need to replace or integrate with
+
+* A proposed set of metrics you'll use to measure your service’s success (and how you'll get them)
+
+* Documentation of the user research and testing you did in the *Prototype* phase
+
+* A timeline and plan for your *Build and Test* phase, including any additional people or resources you'll need
+
+</div>
+<br/>

--- a/_pages/delivery/archive/research-and-discovery-2.md
+++ b/_pages/delivery/archive/research-and-discovery-2.md
@@ -1,0 +1,63 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Research + Discovery activities
+description: During the <i>Research + Discovery</i> phase, focus on answering key questions about the users of the service you plan to build.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Research + Discovery
+page-prev: introduction
+phase-next: Research + Discovery
+page-next: checklist
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/research-and-discovery/activities
+#
+---
+
+### Key questions to answer
+
+* Who are your users?
+* What are they trying to do?
+* What tasks are they trying to accomplish? And how do they do that currently?
+* What problems or frustrations do they experience in trying to achieve their goals?
+* What do users need from your service to achieve their goals?
+* If your research findings show a need for the service, how would you start building a technical solution?
+
+<hr>
+
+### Activities
+
+* Define a **[problem statement]({{site.baseurl}}/resources/more/problem-statement)** that you think your service will solve for your users.
+
+* Conduct **[user research]({{site.baseurl}}/resources/user-research)** to learn about potential users of your service through interviews, observation, and testing.
+
+* Determine your primary user groups.
+
+* Analyze any existing VA or private-sector services that meet user needs.
+
+* Understand current VA policy, technology, and business process related to your service.
+
+* Identify policy, technical, or other barriers that could make it difficult to meet user needs.
+
+* Review the <a title="Go to developer documentation" href="https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/docs/vets-developer-docs/getting-started" target="_blank">**developer documentation**</a> and conduct **[technical discovery]({{site.baseurl}}/resources/more/technical-discovery)**.
+
+* **[Document findings]({{site.baseurl}}/resources/more/research-readout)** from your user research and technical exploration
+
+* Use insights from your findings to create a plan for what the team will work on during the *Prototype* phase
+<br/>

--- a/_pages/delivery/archive/research-and-discovery-3.md
+++ b/_pages/delivery/archive/research-and-discovery-3.md
@@ -1,0 +1,80 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Research + Discovery checklist
+description: The <i>Research + Discovery</i> phase ends with a Checkpoint meeting to confirm your team is ready to move on the <i>Prototype</i> phase.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Research + Discovery
+page-prev: activities
+phase-next: Prototype
+page-next: introduction
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/research-and-discovery/checklist
+#
+---
+
+### By the end of this phase, you should have answers to these questions
+
+
+<div class="bullet-checkmark" markdown="1">
+
+
+* What user problems and needs will the service solve (i.e., what is the scope of the service)?
+
+* What are the specific user stories the service will address?
+
+* What specific things do you plan to prototype and test during the <i>Prototype</i> phase?
+
+* What people and/or resources do you need to support the work during the <i>Prototype</i> phase?
+
+* What are the metrics you'll use to measure the success of the service, and what is your plan to get those metrics?
+
+
+</div>
+
+<hr>
+
+### Completing this phase
+
+#### 1. Schedule a [Checkpoint]({{site.baseurl}}/resources/more/checkpoint) meeting at the end of this phase.
+
+#### 2. At the Checkpoint meeting, be prepared with the following:
+
+
+<div class="bullet-checkmark" markdown="1">
+
+* Your problem statement
+
+* A definition of your primary users
+
+* A list of specific user stories your service will address
+
+* A list of policy, technical, or other barriers that could make it difficult to deliver your service (i.e., risks)
+
+* Your findings from technical discovery
+
+* Your findings from user research
+
+* A timeline and plan for what you'll prototype in the next phase, including any additional people or resources you'll need
+
+* A list of metrics to measure the success of the service (and how you plan to get those metrics)
+
+</div>
+<br/>

--- a/_pages/delivery/build-and-test.md
+++ b/_pages/delivery/build-and-test.md
@@ -1,0 +1,60 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Build and Test introduction
+description: The <i>Build and Test</i> phase is about incrementally building (and testing) the user stories and features you've identified for the MVP. Your goal is to launch the first working version of your service at the end of this phase.  
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Prototype
+page-prev: checklist
+phase-next: Build and Test
+page-next: activities
+#
+# Editable - Timeframe for this phase
+#
+timeframe: |
+  * Different services will spend different amounts of time in the *Build and Test* phase, depending on what the team plans to build as the MVP. In general, plan to spend
+    * 6-8 weeks for a new feature
+    * 8-12 weeks for a new service
+    * **Note**: If your planned MVP will take longer than 12 weeks to build and test, you should reconsider the [scope of your MVP](/va-digital-service-handbook/resources/more/mvp-scope).
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/build-and-test/index.html
+#
+---
+
+### What is the *Build and Test* phase?
+
+In the *Build and Test* phase, it's tempting to try to build all the features and functionality you imagine for your service. But stay focused on your vision for the MVP. **As soon as your service can provide value by meeting basic user needs, it’s ready to launch!**
+
+During this phase, you'll build the user stories and features from your backlog in small batches of functionality. As you build these batches, you'll test them with your users to ensure they work well. Then you'll use that user feedback to refine your service, adding and adjusting features until your MVP service is complete.
+
+The final step in the *Build and Test* phase is to launch the MVP, which you'll do after the Checkpoint meeting.
+
+<hr>
+
+### Planning
+
+{% include phase-planning.html phase="Build and Test" %}
+
+<hr>
+
+### Resources and help
+
+{% include phase-resources.html phase="Build and Test"%}
+<br/>

--- a/_pages/delivery/learn-and-improve.md
+++ b/_pages/delivery/learn-and-improve.md
@@ -1,0 +1,42 @@
+---
+#
+modified-date: September 4, 2018
+# See the Github wiki for how to edit content on this page and markdown styles you can use:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Learn and Improve introduction
+description: The <i>Learn and Improve</i> phase begins after the MVP launch and continues until the service is retired. The goal is to continuously monitor, research, test, and improve for as long as the service is active.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Build and Test
+page-prev: checklist
+phase-next: Learn and Improve
+page-next: activities
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/learn-and-improve/index.html
+#
+---
+
+### What is the *Learn and Improve* phase?
+
+#### content in progress
+
+<hr>
+
+
+### Resources and help
+
+{% include phase-resources.html phase="Learn and Improve"%}
+<br/>

--- a/_pages/delivery/prototype.md
+++ b/_pages/delivery/prototype.md
@@ -1,0 +1,66 @@
+---
+#
+modified-date: September 4, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Prototype introduction
+description: The <i>Prototype</i> phase is about prototyping and testing hypotheses with users so you can decide how to meet the user needs you identified in <i>Research and Discovery</i>. Use this phase as your chance to test many different approaches with real users before building your service.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Research + Discovery
+page-prev: checklist
+phase-next: Prototype
+page-next: activities
+#
+# Editable - Timeframe for this phase
+#
+timeframe: |
+  * Different services will spend different amounts of time in the *Prototype* phase, depending on the complexity of what the team needs to prototype and test. In general, plan to spend
+    * 2 to 4 weeks for a new feature
+    * 6 to 8 weeks for a new service
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/prototype/index.html
+#
+---
+
+### What is the *Prototype* phase?
+
+* The primary objective of the *Prototype* phase is to answer the question: *How can your team best meet the user needs you identified in Research and Discovery?*
+
+* The primary outcome of the *Prototype* phase is *a clear definition of your **Minimum Viable Product (MVP)** and a solid plan for how you'll build it.*
+  <blockquote class="plain-blockquote">
+  <b>The MVP is the first working version of your service</b>, which you'll build in the next phase &mdash; <i>Build and Test</i>.
+  <br/><br/>Your MVP will be the smallest set of working functionality you can build that provides value to your users by meeting basic user needs.
+  <br/><br/>The <i>Prototype</i> phase is about figuring out what those basic user needs are, and how you'll meet them.
+  </blockquote>
+
+During the *Prototype* phase, you'll iteratively design and test potential solutions. You'll build prototypes quickly and test them with users. You'll then use the feedback and testing results to improve the next prototype.
+
+You'll repeat this process until the prototype meets your users' needs and your team is confident they know what the MVP will be and how to build it.
+
+<hr>
+
+### Planning
+
+{% include phase-planning.html phase="Prototype" %}
+
+<hr>
+
+### Resources and help
+
+{% include phase-resources.html phase="Prototype"%}
+<br/>

--- a/_pages/delivery/research-and-discovery.md
+++ b/_pages/delivery/research-and-discovery.md
@@ -1,0 +1,60 @@
+---
+#
+modified-date: September 19, 2018
+#
+# See the Github wiki for how to use Markdown in the editable content below:
+# link here
+#
+# Title and Description display on the page and in HTML meta tags
+#
+title: Research + Discovery introduction
+description: The <i>Research + Discovery</i> phase is not about solutions. It’s about uncovering problems. Before you start designing or building a service, you need to find out who the potential users are and what problems your service could solve for them.
+#
+# Editable - Pagination for bottom of page
+#
+pagination: yes
+phase-prev: Onboard Team
+page-prev: none
+phase-next: Research + Discovery
+page-next: activities
+#
+# Editable - Timeframe for this phase
+#
+timeframe: |
+  * Start the project by putting a time constraint on your *Research and Discovery* work. Plan to spend
+    * 2 to 4 weeks for a new feature
+    * 4 to 8 weeks for a new service
+#
+# Don't edit items below - they control the page layout
+#
+return-top: yes
+layout: page
+page-type: subpage
+page-description: yes
+# same name for sidebar + pagination include
+sidebar-page-type: /delivery
+permalink: /delivery/research-and-discovery/index.html
+#
+---
+
+### What is the *Research + Discovery* phase?
+
+It's tempting to start brainstorming solutions right away based on your understanding of your project. Doing that leads to a solution-focused design process in which your team's primary question is: *How do we build the solution?*
+
+Instead focus on a user-centered design process in which your team's primary questions are: *Who are the potential users of my service, and how can we design a service that meets their needs?*
+
+Your goal in the *Research + Discovery* phase is to **learn about real users and identify the problem(s) your service could solve for them**. The best way to do this is to [talk to real users]({{ site.baseurl}}/resources/user-research). Go out and find people who will be using the service. Talk to them, observe them, and learn what they need and want.
+
+
+<hr>
+
+### Planning
+
+{% include phase-planning.html phase="Research and Discovery" %}
+
+<hr>
+
+### Resources and help
+
+{% include phase-resources.html phase="Research and Discovery"%}
+<br/>


### PR DESCRIPTION
suspicion: the blocked links are associated with pages that aren't an exact match of the `linkto`. 

This PR renames the intended `linkto` files (entails: removing a `-1` suffice from the filename).

