### PR TITLE
update references to old design system

### DIFF
--- a/_pages/digital-standards.md
+++ b/_pages/digital-standards.md
@@ -162,7 +162,7 @@ The user experience of your service must be consistent with other services your 
 
 At a minimum,
 
-* Reuse components from the Veteran-facing Services Platform <a title="Go to Design Patterns" href="https://department-of-veterans-affairs.github.io/design-system/index.html" target="_blank">Design Patterns</a>
+* Reuse components from <a href="https://design.va.gov" target="_blank">Formation</a>, VA.gov’s design system
 * Follow the Veteran-facing Services Platform [Content guide]({{site.baseurl}}/resources/content) for writing copy for your service
 * Make sure your service is responsive and works on mobile devices
 
@@ -188,8 +188,8 @@ Before you design or build anything, think about how these users will access and
 At a minimum,
 
 * Seek a wide variety of users for research and testing, including people with disabilities, other impairments, and those with limited digital experience
-* Reuse components from the Veteran-facing Services Platform <a title="Go to Design Patterns" href="https://department-of-veterans-affairs.github.io/design-system/index.html" target="_blank">Design Patterns</a> (which have already been tested for Section 508 compliance)
-* Use the Veteran-facing Services Platform <a title="Go to Design Guide Colors" href="https://department-of-veterans-affairs.github.io/design-system/components/detail/colors.html" target="_blank">color palette and typography</a> (which have already been tested for Section 508 compliance)
+* Reuse components from <a href="https://design.va.gov" target="_blank">Formation</a>, VA.gov’s design system (which have already been tested for Section 508 compliance)
+* Use Formation’s <a href="https://design.va.gov/design/color-palette" target="_blank">color palette</a> and <a href="https://design.va.gov/design/typography" target="_blank">typography</a> (which have already been tested for Section 508 compliance)
 * Test your service using the simplified process for VA Section 508 compliance (which involves automated tools for testing Section 508 compliance, in addition to periodic manual testing)
 
 <a href="#">Return to top</a>

--- a/_pages/resources/design.md
+++ b/_pages/resources/design.md
@@ -59,7 +59,7 @@ All services on the Veteran-facing Services Platform must work well in desktop, 
 
 **New design patterns**
 
-As we've built out the Veteran-facing Services Platform, we've focused the <a title="Go to design patterns" href="https://department-of-veterans-affairs.github.io/design-system/" target="_blank">design patterns</a> on the immediate design tasks. This means we have not designed for every possible VA scenario.
+As we've built out the Veteran-facing Services Platform, we've focused the <a  href="https://design.va.gov/patterns/" target="_blank">design patterns</a> on the immediate design tasks. This means we have not designed for every possible VA scenario.
 
 In your work, you may find a need for a new design pattern. If that happens, reach out to your DSVA contact, and we'll work together to design it.
 
@@ -209,7 +209,7 @@ When you're designing mockups or prototypes, be sure they include well-written c
 
 #### Design Patterns
 
-The Veteran-facing Services Platform <a title="Go to design patterns" href="https://department-of-veterans-affairs.github.io/design-system/" target="_blank">design patterns</a> make it much easier for designers and developers to quickly prototype pages and forms. The design patterns are the source of truth for the latest templates, interaction design patterns, and visual design.
+The Veteran-facing Services Platform <a href="https://design.va.gov/patterns/" target="_blank">design patterns</a> make it much easier for designers and developers to quickly prototype pages and forms. The design patterns are the source of truth for the latest templates, interaction design patterns, and visual design.
 
 #### Design files
 


### PR DESCRIPTION
Updating references to the old "design system" to point to links on design.va.gov. I didn't really spend much on analyzing the content as a whole but I want to make sure that folks reading the handbook are getting sent to the right place.